### PR TITLE
Fix #4 of https not working

### DIFF
--- a/traefik/03-configmap.yaml
+++ b/traefik/03-configmap.yaml
@@ -16,6 +16,7 @@ data:
         address = ":80"
       [entryPoints.https]
         address = ":443"
+        [entryPoints.https.http.tls]
     [providers]
       [providers.kubernetesCRD]
       # Enable kubernetes ingress provider to expose cert-manager challenge


### PR DESCRIPTION
Fixes issue #4.
Makes https use self-signed tls certificate 